### PR TITLE
Use g3n Node userData instead of string

### DIFF
--- a/game/entity.go
+++ b/game/entity.go
@@ -28,7 +28,7 @@ func Type(entity Entity) EntityType {
 }
 
 // Return this entity's metadata entry at the given index
-func GetDatum(entity Entity, index int) int {
+func Datum(entity Entity, index int) int {
 	data, ok := entity.UserData().(EntityData)
 
 	if ok {

--- a/game/entity.go
+++ b/game/entity.go
@@ -1,10 +1,6 @@
 package game
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/g3n/engine/core"
 )
 
@@ -15,71 +11,40 @@ const Tile EntityType = "tile"
 const Plant EntityType = "plant"
 const Creature EntityType = "creature"
 
-// Metadata format
-// entityType-[gene_0, gene_1, ..., gene_n]
-// genes are strings or ints encoded as strings
+type EntityData struct {
+	eType    EntityType
+	metadata []int
+}
 
-// Generate the metadata tag for an entity
-func CreateTag(entityType EntityType, data []string) (metadata string) {
-	metadata = entityType + "-"
+// Return the type of this entity
+func Type(entity Entity) EntityType {
+	data, ok := entity.UserData().(EntityData)
 
-	for i, datum := range data {
-		metadata += datum
-
-		if i < len(data)-1 {
-			metadata += "-"
-		}
+	if ok {
+		return data.eType
 	}
 
-	return
+	return ""
 }
 
-// Get an entity's type
-func TypeOf(entity Entity) (entityType EntityType) {
-	data := strings.Split(entity.Name(), "-")
-	entityType = data[0]
+// Return this entity's metadata entry at the given index
+func GetDatum(entity Entity, index int) int {
+	data, ok := entity.UserData().(EntityData)
 
-	return
-}
-
-// Get an entity's metadata
-func Metadata(entity Entity) (metadata []string) {
-	data := strings.Split(entity.Name(), "-")
-	metadata = data[1:]
-
-	return
-}
-
-// Get a metadata entry, return empty string if not exist
-func Datum(entity Entity, index int) (datum string) {
-	data := Metadata(entity)
-
-	if index >= 0 && index < len(data) {
-		datum = data[index]
+	if ok {
+		return data.metadata[index]
 	}
 
-	return
+	return 0
 }
 
-// Get a metadata entry as int, return 0 if not exist or failed to decode
-func DatumNum(entity Entity, index int) (datum int) {
-	conv, _ := strconv.ParseInt(Datum(entity, index), 10, 0)
-	datum = int(conv)
+// Set this entity's metadata entry at the given index
+func SetDatum(entity Entity, index int, val int) {
+	data, ok := entity.UserData().(EntityData)
 
-	return
-}
-
-// Modify the value of a metadata entry
-func SetDatum(entity Entity, index int, datum string) {
-	data := Metadata(entity)
-
-	if index >= 0 && index < len(data) {
-		data[index] = datum
-		entity.SetName(CreateTag(TypeOf(entity), data))
+	if ok && index >= 0 && index < len(data.metadata) {
+		metadata := data.metadata
+		metadata[index] = val
+		entity.SetUserData(EntityData{eType: data.eType, metadata: metadata})
 	}
-}
-
-// Modify the value of a numerical metadata entry
-func SetDatumNum(entity Entity, index int, datum int) {
-	SetDatum(entity, index, fmt.Sprintf("%d", datum))
 }

--- a/game/input.go
+++ b/game/input.go
@@ -46,7 +46,7 @@ func MouseDown(evname string, ev interface{}) {
 	if len(i) != 0 {
 		object = i[0].Object.GetNode()
 
-		switch TypeOf(object) {
+		switch Type(object) {
 		case Tile:
 			switch me.Button {
 			case window.MouseButton1:
@@ -69,7 +69,7 @@ func MouseDown(evname string, ev interface{}) {
 				OnRightClickCreature(object)
 			}
 		default:
-			println("No action defined for ", me.Button, " on ", TypeOf(object))
+			println("No action defined for button ", me.Button, " on ", Type(object))
 		}
 	}
 }

--- a/game/plant.go
+++ b/game/plant.go
@@ -16,7 +16,7 @@ func OnLeftClickPlant(plant Entity) {
 
 // Grow the plant slowly over time
 func GrowPlant(plant Entity) {
-	age := GetDatum(plant, PlantAge)
+	age := Datum(plant, PlantAge)
 	age++
 
 	// Grow until maturity is reached

--- a/game/plant.go
+++ b/game/plant.go
@@ -1,5 +1,6 @@
 package game
 
+// Plant metadata mapping
 const PlantColour int = 0
 const PlantAge int = 1
 
@@ -15,7 +16,7 @@ func OnLeftClickPlant(plant Entity) {
 
 // Grow the plant slowly over time
 func GrowPlant(plant Entity) {
-	age := DatumNum(plant, PlantAge)
+	age := GetDatum(plant, PlantAge)
 	age++
 
 	// Grow until maturity is reached
@@ -26,5 +27,5 @@ func GrowPlant(plant Entity) {
 		plant.SetPosition(0, plant.Scale().Y/2, 0)
 	}
 
-	SetDatumNum(plant, PlantAge, age)
+	SetDatum(plant, PlantAge, age)
 }

--- a/game/tile.go
+++ b/game/tile.go
@@ -1,5 +1,9 @@
 package game
 
+// Tile metadata mapping
+const TileX int = 0
+const TileY int = 1
+
 const Water string = "water"
 const Dirt string = "dirt"
 const Grass string = "grass"

--- a/game/world.go
+++ b/game/world.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 
 	"github.com/aquilax/go-perlin"
-	"github.com/g3n/engine/core"
 	"github.com/g3n/engine/geometry"
 	"github.com/g3n/engine/graphic"
 	"github.com/g3n/engine/light"
@@ -23,7 +22,7 @@ func AddPlant(colour int, tile Entity) (success bool) {
 
 	// Check if there is already a plant here
 	for _, child := range tile.Children() {
-		if TypeOf(child.GetNode()) == Plant {
+		if Type(child.GetNode()) == Plant {
 			success = false
 			break
 		}
@@ -40,7 +39,8 @@ func AddPlant(colour int, tile Entity) (success bool) {
 		}
 
 		plant.SetPosition(0, plant.Scale().Y/2, 0)
-		plant.SetName(CreateTag(Plant, []string{fmt.Sprintf("%x", colour), "0"}))
+		plant.SetName(fmt.Sprintf("e_%d", len(Entities)-1))
+		plant.SetUserData(EntityData{eType: Plant, metadata: []int{colour, 0}})
 		tile.Add(plant)
 		Entities[tile.Name()] = tile.ChildAt(len(tile.Children()) - 1).GetNode()
 	}
@@ -60,7 +60,8 @@ func CreateTile(x, y int, tType string) {
 	}
 
 	tile.SetPosition(float32(x)*TileSize, 0, float32(y)*TileSize)
-	tile.SetName(CreateTag(Tile, []string{tType}))
+	tile.SetName(fmt.Sprintf("e%d", len(Entities)+1))
+	tile.SetUserData(EntityData{eType: Tile, metadata: []int{x, y}})
 	Scene.Add(tile)
 	Entities[tile.Name()] = Scene.ChildAt(len(Scene.Children()) - 1).GetNode()
 }
@@ -70,7 +71,7 @@ func LoadWorld() {
 	// Sun
 	Sun = light.NewAmbient(&math32.Color{R: 1.0, G: 1.0, B: 1.0}, 8.0)
 	Scene.Add(Sun)
-	Entities = make(map[string]*core.Node)
+	Entities = make(map[string]Entity)
 
 	// Tiles
 	pnoise := perlin.NewPerlin(1, 0.1, 2, rand.Int63())
@@ -87,7 +88,7 @@ func LoadWorld() {
 // Update the game world, deltaTime is time since last update in ms
 func Update(deltaTime int) {
 	for _, entity := range Entities {
-		switch TypeOf(entity) {
+		switch Type(entity) {
 		case Plant:
 			GrowPlant(entity)
 		}


### PR DESCRIPTION
Replaces the original data encoding system which stored entity's data in the name string with the userData field in core.Node which much more efficiently serves that exact purpose