### PR TITLE
Change terrain from square to hex grid

### DIFF
--- a/game/mesh.go
+++ b/game/mesh.go
@@ -1,0 +1,53 @@
+package game
+
+import (
+	"github.com/g3n/engine/geometry"
+	"github.com/g3n/engine/gls"
+	"github.com/g3n/engine/math32"
+)
+
+// Generate a hexagon mesh with a given width
+func CreateHexagon(size float32) (geom *geometry.Geometry) {
+	geom = geometry.NewGeometry()
+	vertices := math32.NewArrayF32(0, 16)
+	indices := math32.NewArrayU32(0, 16)
+	uvs := math32.NewArrayF32(0, 16)
+
+	// Vertex positioning for a hexagon made of 6 equilateral triangles
+	r := size / 2
+	dx := r * math32.Cos(math32.Pi/3) // This works out to r * 0.5
+	dy := r * math32.Sin(math32.Pi/3) // This works out to r * 0.866
+
+	vertices.Append(
+		0.0, 0.0, 0.0, // centre 0
+		-dx, 0.0, dy, // top left 1
+		dx, 0.0, dy, // top right 2
+		-r, 0.0, 0.0, // middle left 3
+		r, 0.0, 0.0, // middle right 4
+		-dx, 0.0, -dy, // bottom left 5
+		dx, 0.0, -dy, // bottom right 6
+	)
+
+	indices.Append(
+		0, 3, 1, // top left
+		0, 1, 2, // top mid
+		0, 2, 4, // top right
+		0, 4, 6, // bottom right
+		0, 6, 5, // bottom mid
+		0, 5, 3, // bottom left
+	)
+
+	uvs.Append(
+		(r-dx)/size, 1.0, // bottom left
+		0.0, 0.5, // middle left
+		(r-dx)/size, 0.0, // top left
+		(size-dx)/size, 0.0, // top right
+		1.0, 0.5, // middle right
+		(size-dx)/size, 1.0, // bottom right
+	)
+
+	geom.SetIndices(indices)
+	geom.AddVBO(gls.NewVBO(vertices).AddAttrib(gls.VertexPosition))
+	geom.AddVBO(gls.NewVBO(uvs).AddAttrib(gls.VertexTexcoord))
+	return
+}

--- a/game/plant.go
+++ b/game/plant.go
@@ -24,7 +24,7 @@ func GrowPlant(plant Entity) {
 		scale := plant.Scale()
 		scale.Y *= 1.001
 		plant.SetScale(scale.X, scale.Y, scale.Z)
-		plant.SetPosition(0, plant.Scale().Y/2, 0)
+		plant.SetPosition(0, plant.Scale().Y, 0)
 	}
 
 	SetDatum(plant, PlantAge, age)

--- a/game/world.go
+++ b/game/world.go
@@ -48,18 +48,21 @@ func AddPlant(colour int, tile Entity) (success bool) {
 	return
 }
 
-// Spawn a tile of type tType at x, y
+// Spawn a hex tile of type tType at x, y
 func CreateTile(x, y int, tType string) {
-	geom := geometry.NewBox(TileSize, 1, TileSize)
+	geom := CreateHexagon(TileSize)
 	mat := material.NewStandard(math32.NewColorHex(0x111111))
 	tile := graphic.NewMesh(geom, mat)
 	tex, ok := Texture(tType)
+	posX := (float32(x)+(0.5*float32(y%2))) * TileSize * math32.Sin(math32.Pi/3)
+	posZ := float32(y) * TileSize * 0.75
 
 	if ok {
 		mat.AddTexture(tex)
 	}
 
-	tile.SetPosition(float32(x)*TileSize, 0, float32(y)*TileSize)
+	tile.SetPosition(posX, 0, posZ)
+	tile.SetRotationY(math32.Pi / 2)
 	tile.SetName(fmt.Sprintf("e%d", len(Entities)+1))
 	tile.SetUserData(EntityData{eType: Tile, metadata: []int{x, y}})
 	Scene.Add(tile)


### PR DESCRIPTION
Adds a custom mesh generator to make a hexagon which can be built upon to generate other custom meshes
Replaces map generation's square tiles with hexagonal ones 