### PR TITLE
Terrain improvements

### DIFF
--- a/game/entity.go
+++ b/game/entity.go
@@ -6,9 +6,20 @@ import (
 	"github.com/g3n/engine/core"
 )
 
-type EntityType = string
+// Entity data storage model:
+
+// The g3n Node type has a UserData field of type interface{} (the 'any' type)
+// which we can set and get any data we want. Each entity type stores its own struct
+// type (eg Plant entities store PlantData, Tile entities store TileData...)
+// Behind the scenes of the code on this side of the engine, all Entities are
+// pointers to g3n nodes.
+
+// The g3n Node also has a Name field which is used to store the entity type.
+// Entity type is checked when accessing the entity's UserData so that the proper
+// struct fields are used.
+
 type Entity = *core.Node
-type Strand []int
+type EntityType = string
 
 const Tile EntityType = "tile"
 const Plant EntityType = "plant"
@@ -17,26 +28,4 @@ const Creature EntityType = "creature"
 // Return the type of this entity
 func Type(entity Entity) EntityType {
 	return strings.Split(entity.Name(), " ")[0]
-}
-
-// Return this entity's metadata entry at the given index
-func Datum(entity Entity, index int) int {
-	data, ok := entity.UserData().(Strand)
-
-	if ok {
-		return data[index]
-	}
-
-	return 0
-}
-
-// Set this entity's metadata entry at the given index, return whether it could be set
-func SetDatum(entity Entity, index int, val int) (ok bool) {
-	data, ok := entity.UserData().(Strand)
-
-	if ok && index >= 0 && index < len(data) {
-		data[index] = val
-	}
-
-	return
 }

--- a/game/game.go
+++ b/game/game.go
@@ -35,7 +35,7 @@ func buildApplication() {
 
 	// Configure camera
 	Cam = camera.New(1)
-	Cam.SetPosition(float32(Width)*TileSize/2, TileSize, float32(Height)*TileSize/2)
+	Cam.SetPosition(float32(Width)*TileSize/2, TileSize, float32(Depth)*TileSize/2)
 	Cam.SetRotation(-45, 0, 0)
 	Scene.Add(Cam)
 	RegisterControls()

--- a/game/game.go
+++ b/game/game.go
@@ -12,9 +12,6 @@ import (
 	"github.com/g3n/engine/window"
 )
 
-const Width int = 15
-const Height int = 15
-const TileSize float32 = 4
 const SimSpeed int = 60 // Simulation update speed in TPS
 
 var Application *app.Application

--- a/game/input.go
+++ b/game/input.go
@@ -80,5 +80,5 @@ func RegisterControls() {
 	Application.Subscribe(window.OnKeyUp, KeyUp)
 	Application.Subscribe(window.OnKeyRepeat, KeyHold)
 	Application.Subscribe(window.OnMouseDown, MouseDown)
-	camera.NewOrbitControl(Cam).SetTarget(*math32.NewVector3(float32(Width)*TileSize/2, 0, float32(Height)*TileSize/2))
+	camera.NewOrbitControl(Cam).SetTarget(*math32.NewVector3(float32(Width)*TileSize/2, 0, float32(Depth)*TileSize/2))
 }

--- a/game/mesh.go
+++ b/game/mesh.go
@@ -7,17 +7,18 @@ import (
 )
 
 // Generate a hexagon mesh with a given width
-func CreateHexagon(size float32) (geom *geometry.Geometry) {
+func CreateHexagon(width float32) (geom *geometry.Geometry) {
 	geom = geometry.NewGeometry()
 	vertices := math32.NewArrayF32(0, 16)
 	indices := math32.NewArrayU32(0, 16)
 	uvs := math32.NewArrayF32(0, 16)
 
 	// Vertex positioning for a hexagon made of 6 equilateral triangles
-	r := size / 2
-	dx := r * math32.Cos(math32.Pi/3) // This works out to r * 0.5
+	r := width / 2
+	dx := r * math32.Cos(math32.Pi/3) // This works out to r / 2
 	dy := r * math32.Sin(math32.Pi/3) // This works out to r * 0.866
 
+	// List all vertices in the hexagon
 	vertices.Append(
 		0.0, 0.0, 0.0, // centre 0
 		-dx, 0.0, dy, // top left 1
@@ -28,6 +29,7 @@ func CreateHexagon(size float32) (geom *geometry.Geometry) {
 		dx, 0.0, -dy, // bottom right 6
 	)
 
+	// Add triangles' vertices in counter-clockwise
 	indices.Append(
 		0, 3, 1, // top left
 		0, 1, 2, // top mid
@@ -37,13 +39,14 @@ func CreateHexagon(size float32) (geom *geometry.Geometry) {
 		0, 5, 3, // bottom left
 	)
 
+	// Texture mapping, width and height are mapped to [0, 1], origin is top left
 	uvs.Append(
-		(r-dx)/size, 1.0, // bottom left
+		(r-dx)/width, 1.0, // bottom left
 		0.0, 0.5, // middle left
-		(r-dx)/size, 0.0, // top left
-		(size-dx)/size, 0.0, // top right
+		(r-dx)/width, 0.0, // top left
+		(width-dx)/width, 0.0, // top right
 		1.0, 0.5, // middle right
-		(size-dx)/size, 1.0, // bottom right
+		(width-dx)/width, 1.0, // bottom right
 	)
 
 	geom.SetIndices(indices)

--- a/game/mesh.go
+++ b/game/mesh.go
@@ -6,8 +6,8 @@ import (
 	"github.com/g3n/engine/math32"
 )
 
-// Generate a hexagon mesh with a given width
-func CreateHexagon(width float32) (geom *geometry.Geometry) {
+// Generate a hexagon mesh with a given width and height
+func CreateHexagon(width, height float32) (geom *geometry.Geometry) {
 	geom = geometry.NewGeometry()
 	vertices := math32.NewArrayF32(0, 16)
 	indices := math32.NewArrayU32(0, 16)
@@ -18,15 +18,21 @@ func CreateHexagon(width float32) (geom *geometry.Geometry) {
 	dx := r * math32.Cos(math32.Pi/3) // This works out to r / 2
 	dy := r * math32.Sin(math32.Pi/3) // This works out to r * 0.866
 
-	// List all vertices in the hexagon
+	// List all vertices in the hexagon as though looking at the front each face
 	vertices.Append(
-		0.0, 0.0, 0.0, // centre 0
-		-dx, 0.0, dy, // top left 1
-		dx, 0.0, dy, // top right 2
-		-r, 0.0, 0.0, // middle left 3
-		r, 0.0, 0.0, // middle right 4
-		-dx, 0.0, -dy, // bottom left 5
-		dx, 0.0, -dy, // bottom right 6
+		0.0, 0.0, 0.0, // surface: centre 0
+		-dx, 0.0, dy, // surface: top left 1
+		dx, 0.0, dy, // surface: top right 2
+		-r, 0.0, 0.0, // surface: middle left 3
+		r, 0.0, 0.0, // surface: middle right 4
+		-dx, 0.0, -dy, // surface: bottom left 5
+		dx, 0.0, -dy, // surface: bottom right 6
+		-dx, -height, dy, // sides: top left 7
+		dx, -height, dy, // sides: top right 8
+		-r, -height, 0.0, // sides: middle left 9
+		r, -height, 0.0, // sides: middle right 10
+		-dx, -height, -dy, // sides: bottom left 11
+		dx, -height, -dy, // sides: bottom right 12
 	)
 
 	// Add triangles' vertices in counter-clockwise
@@ -37,6 +43,18 @@ func CreateHexagon(width float32) (geom *geometry.Geometry) {
 		0, 4, 6, // bottom right
 		0, 6, 5, // bottom mid
 		0, 5, 3, // bottom left
+		1, 9, 7, // top left side 1
+		3, 9, 1, // top left side 2
+		7, 8, 2, // top side 1
+		7, 2, 1, // top side 2
+		8, 10, 4, // top right side 1
+		8, 4, 2, // top right side 2
+		10, 12, 6, // bottom right side 1
+		10, 6, 4, // bottom right side 2
+		12, 11, 5, // bottom side 1
+		12, 5, 6, // bottom side 2
+		11, 9, 3, // bottom left side 1
+		5, 11, 3, // bottom left side 2
 	)
 
 	// Texture mapping, width and height are mapped to [0, 1], origin is top left
@@ -52,6 +70,6 @@ func CreateHexagon(width float32) (geom *geometry.Geometry) {
 	geom.SetIndices(indices)
 	geom.AddVBO(gls.NewVBO(vertices).AddAttrib(gls.VertexPosition))
 	geom.AddVBO(gls.NewVBO(uvs).AddAttrib(gls.VertexTexcoord))
-	
+
 	return
 }

--- a/game/mesh.go
+++ b/game/mesh.go
@@ -52,5 +52,6 @@ func CreateHexagon(width float32) (geom *geometry.Geometry) {
 	geom.SetIndices(indices)
 	geom.AddVBO(gls.NewVBO(vertices).AddAttrib(gls.VertexPosition))
 	geom.AddVBO(gls.NewVBO(uvs).AddAttrib(gls.VertexTexcoord))
+	
 	return
 }

--- a/game/plant.go
+++ b/game/plant.go
@@ -7,9 +7,11 @@ import (
 	"github.com/g3n/engine/math32"
 )
 
-// Plant metadata mapping
-const PlantColour int = 0
-const PlantAge int = 1
+// Which data a Plant will store
+type PlantData struct {
+	Colour int
+	Age    int
+}
 
 // Perform action on plant entity on right click
 func OnRightClickPlant(plant Entity) {
@@ -34,23 +36,24 @@ func NewPlant(colour int) (plant *graphic.Mesh) {
 
 	plant.SetPosition(0, plant.Scale().Y/2, 0)
 	plant.SetName(Plant)
-	plant.SetUserData(Strand{colour, 0})
+	plant.SetUserData(PlantData{Colour: colour, Age: 0})
 
 	return
 }
 
-// Grow the plant slowly over time
-func GrowPlant(plant Entity) {
-	age := Datum(plant, PlantAge)
-	age++
+// Perform per-frame updates to a plant
+func UpdatePlant(plant Entity) {
+	data, _ := plant.UserData().(PlantData)
+	data.Age++
 
 	// Grow until maturity is reached
-	if age < 1000 {
+	if data.Age < 1000 {
 		scale := plant.Scale()
 		scale.Y *= 1.001
 		plant.SetScale(scale.X, scale.Y, scale.Z)
 		plant.SetPosition(0, plant.Scale().Y, 0)
 	}
 
-	SetDatum(plant, PlantAge, age)
+	// Update changes to the plant data
+	plant.SetUserData(data)
 }

--- a/game/tile.go
+++ b/game/tile.go
@@ -10,7 +10,7 @@ import (
 
 // Tile metadata mapping
 const TileX int = 0  // Position in the tilemap, not the game world
-const TilyY int = 1  // These x and y values are used to access the tile's neighbourhood (TODO)
+const TilyZ int = 1  // These x and z values are used to access the tile's neighbourhood (TODO)
 const TileT int = 2
 
 type TileType = string
@@ -38,23 +38,23 @@ func OnLeftClickTile(tile Entity) {
 	println("No left click behaviour defined for ", tile.Name())
 }
 
-// Spawn a hex tile of type tType at x, z (tile precision) at height y (game world precision)
-func NewTile(x, z int, y float32, tType TileType) (tile *graphic.Mesh) {
+// Spawn a hex tile of type tType at mapX, mapZ (tile precision), y (game world precision)
+func NewTile(mapX, mapZ int, y float32, tType TileType) (tile *graphic.Mesh) {
 	geom := CreateHexagon(TileSize)
 	mat := material.NewStandard(math32.NewColorHex(0x111111))
 	tile = graphic.NewMesh(geom, mat)
 	tex, ok := Texture(tType)
-	posX := (float32(x) + (0.5 * float32(z%2))) * TileSize * math32.Sin(math32.Pi/3)
-	posZ := float32(z) * TileSize * 0.75
+	x := (float32(mapX) + (0.5 * float32(mapZ%2))) * TileSize * math32.Sin(math32.Pi/3)
+	z := float32(mapZ) * TileSize * 0.75
 
 	if ok {
 		mat.AddTexture(tex)
 	}
 
-	tile.SetPosition(posX, 0, posZ)
+	tile.SetPosition(x, y, z)
 	tile.SetRotationY(math32.Pi / 2)
 	tile.SetName(fmt.Sprintf("%s (%s)", Tile, tType))
-	tile.SetUserData(Strand{x, z, TypeIndex(tType)})
+	tile.SetUserData(Strand{mapX, mapZ, TypeIndex(tType)})
 
 	return
 }

--- a/game/tile.go
+++ b/game/tile.go
@@ -8,11 +8,6 @@ import (
 	"github.com/g3n/engine/math32"
 )
 
-// Tile metadata mapping
-const TileX int = 0  // Position in the tilemap, not the game world
-const TilyZ int = 1  // These x and z values are used to access the tile's neighbourhood (TODO)
-const TileT int = 2
-
 type TileType = string
 
 const Water TileType = "water"
@@ -28,9 +23,20 @@ var TileTypes []TileType = []TileType{
 	Stone,
 }
 
+// Which data a tile will store
+type TileData struct {
+	MapX int
+	MapZ int
+	// No need for MapY as tiles are not stacked
+	// World (x, y, z) stored in tile.Position()
+	Type TileType
+}
+
 // Perform an action on a tile entity on right click
 func OnRightClickTile(tile Entity) {
-	AddEntityTo(tile, NewPlant(0x00dd05))
+	if !HasPlant(tile) {
+		AddEntityTo(tile, NewPlant(0x00dd05))
+	}
 }
 
 // Perform an action on a tile entity on left click
@@ -54,7 +60,7 @@ func NewTile(mapX, mapZ int, y float32, tType TileType) (tile *graphic.Mesh) {
 	tile.SetPosition(x, y, z)
 	tile.SetRotationY(math32.Pi / 2)
 	tile.SetName(fmt.Sprintf("%s (%s)", Tile, tType))
-	tile.SetUserData(Strand{mapX, mapZ, TypeIndex(tType)})
+	tile.SetUserData(TileData{MapX: mapX, MapZ: mapZ, Type: tType})
 
 	return
 }
@@ -79,4 +85,9 @@ func HasPlant(tile Entity) bool {
 	}
 
 	return false
+}
+
+// Perform per-frame updates to a Tile
+func UpdateTile(tile Entity) {
+
 }

--- a/game/tile.go
+++ b/game/tile.go
@@ -50,7 +50,7 @@ func OnLeftClickTile(tile Entity) {
 
 // Spawn a hex tile of type tType at mapX, mapZ (tile precision), y (game world precision)
 func NewTile(mapX, mapZ int, y float32, tType TileType) (tile *graphic.Mesh) {
-	geom := CreateHexagon(TileSize)
+	geom := CreateHexagon(TileSize, y)
 	mat := material.NewStandard(math32.NewColorHex(0x111111))
 	tile = graphic.NewMesh(geom, mat)
 	tex, ok := Texture(tType)

--- a/game/tile.go
+++ b/game/tile.go
@@ -9,17 +9,19 @@ import (
 )
 
 // Tile metadata mapping
-const TileX int = 0
-const TileY int = 1
+const TileX int = 0  // Position in the tilemap, not the game world
+const TilyY int = 1  // These x and y values are used to access the tile's neighbourhood (TODO)
 const TileT int = 2
 
-const Water string = "water"
-const Dirt string = "dirt"
-const Grass string = "grass"
-const Stone string = "stone"
+type TileType = string
+
+const Water TileType = "water"
+const Dirt TileType = "dirt"
+const Grass TileType = "grass"
+const Stone TileType = "stone"
 
 // Store list of tile types ordered by spawn height
-var TileTypes []string = []string{
+var TileTypes []TileType = []TileType{
 	Water,
 	Dirt,
 	Grass,
@@ -28,7 +30,7 @@ var TileTypes []string = []string{
 
 // Perform an action on a tile entity on right click
 func OnRightClickTile(tile Entity) {
-	AddPlantTo(tile, 0x00dd05)
+	AddEntityTo(tile, NewPlant(0x00dd05))
 }
 
 // Perform an action on a tile entity on left click
@@ -36,14 +38,14 @@ func OnLeftClickTile(tile Entity) {
 	println("No left click behaviour defined for ", tile.Name())
 }
 
-// Spawn a hex tile of type tType at x, y
-func NewTile(x, y int, tType string) (tile *graphic.Mesh) {
+// Spawn a hex tile of type tType at x, z (tile precision) at height y (game world precision)
+func NewTile(x, z int, y float32, tType TileType) (tile *graphic.Mesh) {
 	geom := CreateHexagon(TileSize)
 	mat := material.NewStandard(math32.NewColorHex(0x111111))
 	tile = graphic.NewMesh(geom, mat)
 	tex, ok := Texture(tType)
-	posX := (float32(x) + (0.5 * float32(y%2))) * TileSize * math32.Sin(math32.Pi/3)
-	posZ := float32(y) * TileSize * 0.75
+	posX := (float32(x) + (0.5 * float32(z%2))) * TileSize * math32.Sin(math32.Pi/3)
+	posZ := float32(z) * TileSize * 0.75
 
 	if ok {
 		mat.AddTexture(tex)
@@ -52,13 +54,13 @@ func NewTile(x, y int, tType string) (tile *graphic.Mesh) {
 	tile.SetPosition(posX, 0, posZ)
 	tile.SetRotationY(math32.Pi / 2)
 	tile.SetName(fmt.Sprintf("%s (%s)", Tile, tType))
-	tile.SetUserData(Strand{x, y, TypeIndex(tType)})
+	tile.SetUserData(Strand{x, z, TypeIndex(tType)})
 
 	return
 }
 
 // Check what index of the tile types strata a type is, return -1 if invalid type
-func TypeIndex(tType string) int {
+func TypeIndex(tType TileType) int {
 	for i, t := range TileTypes {
 		if t == tType {
 			return i
@@ -78,17 +80,3 @@ func HasPlant(tile Entity) bool {
 
 	return false
 }
-
-// Add a plant with given genetics to a given tile, return whether the plant was added
-func AddPlantTo(tile Entity, colour int) (success bool) {
-	success = !HasPlant(tile)
-
-	if success {
-		AddEntityTo(tile, NewPlant(colour))
-	}
-
-	return
-}
-
-// TODO: Remove a plant from a tile
-// func RemovePlant(tile Entity, plant Plant) (success bool) { return false }

--- a/game/tile.go
+++ b/game/tile.go
@@ -19,7 +19,7 @@ const Grass string = "grass"
 const Stone string = "stone"
 
 // Store list of tile types ordered by spawn height
-var TypeStrata []string = []string{
+var TileTypes []string = []string{
 	Water,
 	Dirt,
 	Grass,
@@ -59,7 +59,7 @@ func NewTile(x, y int, tType string) (tile *graphic.Mesh) {
 
 // Check what index of the tile types strata a type is, return -1 if invalid type
 func TypeIndex(tType string) int {
-	for i, t := range TypeStrata {
+	for i, t := range TileTypes {
 		if t == tType {
 			return i
 		}

--- a/game/tile.go
+++ b/game/tile.go
@@ -23,13 +23,17 @@ var TileTypes []TileType = []TileType{
 	Stone,
 }
 
+// Represents the tiles surrounding this one
+type Neighbourhood = [6]Entity
+
 // Which data a tile will store
 type TileData struct {
 	MapX int
 	MapZ int
 	// No need for MapY as tiles are not stacked
 	// World (x, y, z) stored in tile.Position()
-	Type TileType
+	Type       TileType
+	Neighbours Neighbourhood
 }
 
 // Perform an action on a tile entity on right click

--- a/game/world.go
+++ b/game/world.go
@@ -18,7 +18,7 @@ const TileSize float32 = 4
 var Sun *light.Ambient
 var Entities map[int]Entity
 
-// Add an entity to the entity list
+// Add an entity to the game
 func AddEntityTo(node *core.Node, entity *graphic.Mesh) {
 	node.Add(entity)
 	Entities[len(Entities)] = node.ChildAt(len(node.Children()) - 1).GetNode()
@@ -91,13 +91,17 @@ func LoadWorld() {
 		}
 	}
 
-	// Add tiles to world
+	// Add tiles to world, keep temporary record of the tilemap to assign tile neighbourhoods
+	var tileMap [Width][Depth]Entity
+
 	for x := 0; x < Width; x++ {
 		for z := 0; z < Depth; z++ {
 			// Map the heightmap value to the TileTypes array to determine tile type
 			y := math32.Min(float32(len(TileTypes))*(heightmap[x][z]-min)/(max-min), float32(len(TileTypes)-1))
 			tType := TileTypes[int(y)]
-			AddEntityTo(Scene, NewTile(x, z, y, tType))
+			tile := NewTile(x, z, y, tType)
+			AddEntityTo(Scene, tile)
+			tileMap[x][z] = tile.GetNode()
 		}
 	}
 }
@@ -107,7 +111,9 @@ func Update(deltaTime int) {
 	for _, entity := range Entities {
 		switch Type(entity) {
 		case Plant:
-			GrowPlant(entity)
+			UpdatePlant(entity)
+		case Tile:
+			UpdateTile(entity)
 		}
 	}
 }

--- a/game/world.go
+++ b/game/world.go
@@ -26,6 +26,7 @@ func AddEntityTo(node *core.Node, entity *graphic.Mesh) {
 
 // Remove an entity from the world
 func RemoveEntity(entity Entity) {
+	// Recursively remove children of this entity
 	for _, child := range entity.Children() {
 		RemoveEntity(child.GetNode())
 	}
@@ -70,13 +71,13 @@ func LoadWorld() {
 	pnoise := perlin.NewPerlin(1, 0.1, 2, rand.Int63())
 
 	// Create heightmap
-	var heightmap [Width][Height]float64
-	min  := 1_000_000_000.0
-	max := -min
+	var heightmap [Width][Height]float32
+	var min float32 = 1_000_000_000.0
+	var max float32 = -min
 
 	for y := 0; y < Height; y++ {
 		for x := 0; x < Width; x++ {
-			height := math.Abs(pnoise.Noise2D(float64(x), float64(y)) * 1000) 
+			height := float32(math.Abs(pnoise.Noise2D(float64(x), float64(y)) * 1000)) 
 			heightmap[x][y] = height
 
 			// Record min and max so that the tile types can be mapped to height range
@@ -90,12 +91,15 @@ func LoadWorld() {
 		}
 	}
 
+	// Add tiles to world
+	// The x, y values from the 2d tilemap are mapped to x, z in the game world
+	// The heightmap value at x, y is mapped to y in the game world 
 	for y := 0; y < Height; y++ {
 		for x := 0; x < Width; x++ {
-			// Construct the tile at x, y
-			typeIndex := int(math.Min(float64(len(TileTypes)) * (heightmap[x][y]-min)/(max - min), float64(len(TileTypes) - 1)))
+			// Construct the tile at x, y, use heightmap value at x, y to determine tile type
+			typeIndex := int(math32.Min(float32(len(TileTypes)) * (heightmap[x][y]-min)/(max - min), float32(len(TileTypes) - 1)))
 			tType := TileTypes[typeIndex]
-			AddEntityTo(Scene, NewTile(x, y, tType))
+			AddEntityTo(Scene, NewTile(x, y, heightmap[x][y], tType))
 		}
 	}
 }

--- a/game/world.go
+++ b/game/world.go
@@ -12,7 +12,7 @@ import (
 )
 
 const Width int = 64
-const Height int = 64
+const Depth int = 64
 const TileSize float32 = 4
 
 var Sun *light.Ambient
@@ -71,17 +71,17 @@ func LoadWorld() {
 	pnoise := perlin.NewPerlin(1, 0.1, 2, rand.Int63())
 
 	// Create heightmap
-	var heightmap [Width][Height]float32
+	var heightmap [Width][Depth]float32
 	var min float32 = 1_000_000_000.0
 	var max float32 = -min
 
-	for y := 0; y < Height; y++ {
-		for x := 0; x < Width; x++ {
-			height := float32(math.Abs(pnoise.Noise2D(float64(x), float64(y)) * 1000)) 
-			heightmap[x][y] = height
+	for x := 0; x < Width; x++ {
+		for z := 0; z < Depth; z++ {
+			height := float32(math.Abs(pnoise.Noise2D(float64(x), float64(z)) * 1000))
+			heightmap[x][z] = height
 
 			// Record min and max so that the tile types can be mapped to height range
-			if height < min{
+			if height < min {
 				min = height
 			}
 
@@ -92,14 +92,12 @@ func LoadWorld() {
 	}
 
 	// Add tiles to world
-	// The x, y values from the 2d tilemap are mapped to x, z in the game world
-	// The heightmap value at x, y is mapped to y in the game world 
-	for y := 0; y < Height; y++ {
-		for x := 0; x < Width; x++ {
-			// Construct the tile at x, y, use heightmap value at x, y to determine tile type
-			typeIndex := int(math32.Min(float32(len(TileTypes)) * (heightmap[x][y]-min)/(max - min), float32(len(TileTypes) - 1)))
-			tType := TileTypes[typeIndex]
-			AddEntityTo(Scene, NewTile(x, y, heightmap[x][y], tType))
+	for x := 0; x < Width; x++ {
+		for z := 0; z < Depth; z++ {
+			// Map the heightmap value to the TileTypes array to determine tile type
+			y := math32.Min(float32(len(TileTypes))*(heightmap[x][z]-min)/(max-min), float32(len(TileTypes)-1))
+			tType := TileTypes[int(y)]
+			AddEntityTo(Scene, NewTile(x, z, y, tType))
 		}
 	}
 }

--- a/game/world.go
+++ b/game/world.go
@@ -20,6 +20,41 @@ func AddEntityTo(node *core.Node, entity *graphic.Mesh) {
 	Entities[len(Entities)] = node.ChildAt(len(node.Children()) - 1).GetNode()
 }
 
+// Remove an entity from the world
+func RemoveEntity(entity Entity) {
+	for _, child := range entity.Children(){
+		RemoveEntity(child.GetNode())
+	}
+
+	dropEntity(entity)
+	entity.SetVisible(false)
+	entity.RemoveAll(true)
+	entity.Parent().GetNode().Remove(entity)
+	entity.DisposeChildren(true)
+	entity.Dispose()
+}
+
+// Remove an entity from the Entities list
+func dropEntity(entity Entity) {
+	index := -1
+
+	// Find the entity's index in the Entities list
+	for i, ent := range Entities {
+		if ent == entity {
+			index = i
+			break
+		}
+	}
+
+	// If the entity is in the Entities list, remove it and shift all the entities above it down the list
+	if index >= 0 {
+		for i := index + 1; i < len(Entities); i++ {
+			Entities[i - 1] = Entities[i]
+		}
+		delete(Entities, len(Entities) - 1)
+	}
+}
+
 // Load the world into the scene
 func LoadWorld() {
 	// Sun


### PR DESCRIPTION
- Rewrites the Entity framework to be more efficient and give each entity their own metadata structure. 
- Increases the map size from 15x15 to 64x64
- Changes tile shape from square to hexagon
- Worldgen creates heightmap and determines tile type with Perlin noise
- Tile heights are set by heightmap
- Tiles now have list of pointers to their neighbours